### PR TITLE
Small typo, plus a helper script and private key explanation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Environment setup
 
-- `pip install requirements.txt`
+- `pip install -r requirements.txt`
 
 - Configure a `config.yml` file with the properties shown below:
 
@@ -19,6 +19,11 @@
     private_key: PRIVATE_KEY_VALUE
     public_key: PUBLIC_KEY_VALUE
   ```
+
+The private keys are expected to be base64 encoded.  You can use
+`python create-account.py` to create a new account and print the keys
+in the proper format.  You can fund these new accounts using the
+[Algorand TestNet Dispenser](https://bank.testnet.algorand.network/)
 
 ## Overview
 

--- a/create-account.py
+++ b/create-account.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+import base64
+from typing import List, Any, Optional
+import algosdk
+
+
+sk, pk = algosdk.account.generate_account()
+print(f"""
+  private_key: {sk}
+  public_key: {pk}
+""")


### PR DESCRIPTION
There's a missing `-r` in the pip install command.

I also added an explanation for how private keys should be put into the yaml file (I think many people might think you're looking for the mnemonic there), and a script to generate accounts and emit them in the right format.
